### PR TITLE
typo fixes

### DIFF
--- a/docs/develop.md
+++ b/docs/develop.md
@@ -10,6 +10,7 @@ The following tools should be installed:
 - **Git**: Highly recommended for version control.
 - **BepInEx**: The mod loader. This either should be installed with the game directly, or there should be a dedicated development profile in a mod manager.
 
+
 # Creating a Plugin Project
 
 This tutorial walks through the process of developing a BepInEx mod for R.E.P.O. using [Repo Modding SDKs and Templates](https://github.com/linkoid/Repo.Sdks#readme). This streamlines mod development by automating game detection, using best practices, and simplifying the build process.


### PR DESCRIPTION
I tried to start modding on my Linux machine, which was naive, I know. But the mention of a "Terminal" which was not specified as "PowerShell" made me optimistically curious. When I realized the window for the BepInEx console can in no way be properly spawned when the game is run with Proton, I stopped and thought I suggest this little addition.