### PR TITLE
Update R.E.P.O. Unity Project Setup Tutorial

### DIFF
--- a/docs/unity.md
+++ b/docs/unity.md
@@ -16,7 +16,7 @@ The Unity workflow is primarly needed for creating Enemies, Levels, Valuables an
 
 - **Unity Hub:** Download & Install [Unity Hub](https://unity.com/download).
 - **Unity Editor:** Install the Unity Editor version [2022.3.62f3](unityhub://2022.3.62f3/96770f904ca7).
-- **.NET SDK:** Version 6.0 or higher. This is required for AssetRipper to Run. 
+- **.NET SDK:** [Version 9.0.](https://dotnet.microsoft.com/fr-fr/download/dotnet/thank-you/runtime-9.0.15-windows-x64-installer). This is required for AssetRipper to Run.
 - **Git:** Download & Install [Git](https://git-scm.com/downloads). This is required for installing packages via Git URL in Unity.
 <!-- NOTE: AssetRipper may be updated with a more Recent build which will Require .Net SDK 10 in the Future -->
 


### PR DESCRIPTION
As in now, may 5th 2026, the required version of the .NET SDK is v9.0.15, not "version 6 or above".

I've hit my head a lot with this one lol, I just want to help